### PR TITLE
Modify news preview image mouse hover effects.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -187,4 +187,13 @@ body {
   .virtual-link {
     i { padding-right: 7px; }
   }
+
+  .img-holder img {
+    transform: scale(1, 1);
+    opacity: 1;
+  }
+
+  &:hover {
+    .img-holder img { opacity: .5; }
+  }
 }

--- a/app/views/news/_news.html.slim
+++ b/app/views/news/_news.html.slim
@@ -3,11 +3,6 @@
     .col-md-6
       .img-holder
         = image_tag news.thumbnail_url(:thumb)
-        .overlay-style-one
-          .box
-            .content
-              = link_to news do
-                i.fa.fa-link
         .post-date
           h3
             | #{news.created_at.day}

--- a/app/views/pages/index/_news.html.slim
+++ b/app/views/pages/index/_news.html.slim
@@ -13,11 +13,6 @@ section.latest-blog-area
                 .col-md-6
                   .img-holder
                     = image_tag news.thumbnail_url(:thumb)
-                    .overlay-style-one
-                      .box
-                        .content
-                          = link_to news do
-                            i.fa.fa-link
                     .post-date
                       h3
                         | #{news.created_at.day}


### PR DESCRIPTION
modify mouse:hover behavior of news preview image
apply the same transition style as speaker avatar 
see issue  #146  


- modify news#index styles  5cf84fb
- modify index/_news html, remove overlay 8ac55b0

![temp](https://user-images.githubusercontent.com/12843409/43059833-eaa9ba94-8e80-11e8-9071-b7ec2bd5229a.gif)
